### PR TITLE
Caching headers

### DIFF
--- a/imagehoster/app/server/amazon-bucket.js
+++ b/imagehoster/app/server/amazon-bucket.js
@@ -32,3 +32,7 @@ export function waitFor(method, params/*, responseHeaders*/) {
         });
     })
 }
+
+export function getObjectUrl({Key, Bucket}) {
+    return `https://${ Bucket }.s3.amazonaws.com/${ Key }`
+}

--- a/imagehoster/app/server/data-server.js
+++ b/imagehoster/app/server/data-server.js
@@ -1,6 +1,6 @@
 import config from 'config'
-import {s3} from 'app/server/amazon-bucket'
-import {missing, getRemoteIp, limit, getObjectUrl} from 'app/server/utils-koa'
+import {s3, getObjectUrl} from 'app/server/amazon-bucket'
+import {missing, getRemoteIp, limit} from 'app/server/utils-koa'
 
 const {uploadBucket} = config
 

--- a/imagehoster/app/server/data-server.js
+++ b/imagehoster/app/server/data-server.js
@@ -1,6 +1,6 @@
 import config from 'config'
 import {s3} from 'app/server/amazon-bucket'
-import {missing, getRemoteIp, limit} from 'app/server/utils-koa'
+import {missing, getRemoteIp, limit, getObjectUrl} from 'app/server/utils-koa'
 
 const {uploadBucket} = config
 
@@ -16,11 +16,13 @@ router.get('/:hash/:filename?', function *() {
         const {hash} = this.params
         const key = `${hash}`
 
-        const params = {Bucket: uploadBucket, Key: key, Expires: 60};
-        const url = s3.getSignedUrl('getObject', params);
-        // console.log("get URL is", url);
-        this.redirect(url)
-        
+        // This lets us remove images even if the s3 bucket cache is public,immutable
+        // Clients will have to re-evaulate the 302 redirect every day
+        this.status = 302
+        this.set('Cache-Control', 'public,max-age=86400')
+
+        this.redirect(getObjectUrl({Bucket: uploadBucket, Key: key}))
+
         // yield new Promise(resolve => {
         //     const params = {Bucket: uploadBucket, Key: key};
         //     s3.getObject(params, (err, data) => {

--- a/imagehoster/app/server/image-proxy.js
+++ b/imagehoster/app/server/image-proxy.js
@@ -9,6 +9,8 @@ import request from 'request'
 import sharp from 'sharp'
 
 const {uploadBucket, webBucket, thumbnailBucket} = config
+const putOptions = {CacheControl: 'public,max-age=604800'}
+
 const TRACE = process.env.STEEMIT_IMAGEPROXY_TRACE || false
 
 const router = require('koa-router')()
@@ -76,7 +78,6 @@ router.get('/:width(\\d+)x:height(\\d+)/:url(.*)', function *() {
     const Bucket = isUpload ? uploadBucket : webBucket
     const originalKey = {Bucket, Key}
     const webBucketKey = {Bucket: webBucket, Key}
-    const putOptions = {CacheControl: 'public,max-age=31536000,immutable'}
 
     const resizeRequest = targetWidth !== 0 || targetHeight !== 0
     if(resizeRequest) {
@@ -113,9 +114,6 @@ router.get('/:width(\\d+)x:height(\\d+)/:url(.*)', function *() {
         if(!imageResult) {
             return
         }
-
-        if(TRACE) console.log('image-proxy -> original save', url, JSON.stringify(webBucketKey, null, 0))
-        yield s3call('putObject', Object.assign({}, webBucketKey, imageResult, putOptions))
 
         if(fullSize && imageResult.ContentType === 'image/gif') {
             // Case 2 of 2: initial fetch

--- a/imagehoster/app/server/image-proxy.js
+++ b/imagehoster/app/server/image-proxy.js
@@ -80,7 +80,7 @@ router.get('/:width(\\d+)x:height(\\d+)/:url(.*)', function *() {
     const webBucketKey = {Bucket: webBucket, Key}
 
     const resizeRequest = targetWidth !== 0 || targetHeight !== 0
-    if(resizeRequest) {
+    if(resizeRequest) { // This is always true...
         const resizedKey = Key + `_${targetWidth}x${targetHeight}`
         const thumbnailKey = {Bucket: thumbnailBucket, Key: resizedKey}
 
@@ -146,6 +146,7 @@ router.get('/:width(\\d+)x:height(\\d+)/:url(.*)', function *() {
     }
 
     // A full size image
+    throw 'NEVER REACHED'
 
     const hasOriginal = !!(yield s3call('headObject', originalKey))
     if(hasOriginal) {

--- a/imagehoster/app/server/upload-data.js
+++ b/imagehoster/app/server/upload-data.js
@@ -196,7 +196,7 @@ router.post('/:username/:signature', koaBody, function *() {
         }
     }
 
-    const params = {Bucket: uploadBucket, Key: key, Body: fbuffer};
+    const params = {Bucket: uploadBucket, Key: key, Body: fbuffer, CacheControl: 'public,max-age=31536000,immutable'};
     if(mime) {
         params.ContentType = mime
     }


### PR DESCRIPTION
Internal PR for #33 

Closes #32 

This also fixes a bug that caused the original image to be re-uploaded for every thumbnail miss and uploaded twice on the initial fetch

@sneak Added 2 commits since your last review, please have a look. I didn't refactor the unreachable code to keep the diff small and since we are throwing this all away at some point.