### PR TITLE
Community - Automatically rotate images

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/node": "^10.5.2",
     "@types/ratelimiter": "^2.1.28",
     "@types/redis": "^2.8.5",
-    "@types/sharp": "^0.17.6",
+    "@types/sharp": "^0.21.0",
     "lodash": "^4.17.12",
     "mocha": "^5.1.1",
     "mocha-junit-reporter": "^1.17.0",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -325,7 +325,7 @@ export async function proxyHandler(ctx: KoaContext) {
                 if (!width) { width = maxWidth }
                 if (!height) { height = maxHeight }
 
-                image.rotate().resize(width, height).max().withoutEnlargement()
+                image.rotate().resize(width, height, { fit: 'inside', withoutEnlargement: true })
                 break
         }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -319,13 +319,13 @@ export async function proxyHandler(ctx: KoaContext) {
 
         switch (options.mode) {
             case ScalingMode.Cover:
-                image.resize(width, height).crop()
+                image.rotate().resize(width, height).crop()
                 break
             case ScalingMode.Fit:
                 if (!width) { width = maxWidth }
                 if (!height) { height = maxHeight }
 
-                image.resize(width, height).max().withoutEnlargement()
+                image.rotate().resize(width, height).max().withoutEnlargement()
                 break
         }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -319,7 +319,7 @@ export async function proxyHandler(ctx: KoaContext) {
 
         switch (options.mode) {
             case ScalingMode.Cover:
-                image.rotate().resize(width, height).crop()
+                image.rotate().resize(width, height, {fit: 'cover'})
                 break
             case ScalingMode.Fit:
                 if (!width) { width = maxWidth }

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,10 +286,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@types/sharp@^0.17.6":
-  version "0.17.10"
-  resolved "https://registry.yarnpkg.com/@types/sharp/-/sharp-0.17.10.tgz#4f546861c53fae2b1bffcdd1ae7e691cc68afa52"
-  integrity sha512-nISitptrYm6hUpiC+vN21cbT8Of54TubXY95N+pcqNCmmXZqd1hRk7fC5HYRRQwWJiKV/NLHx8f4CxPIsIQXqg==
+"@types/sharp@^0.21.0":
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/@types/sharp/-/sharp-0.21.3.tgz#82f89f99536557e397c0c46f5ea50dcc1529fe35"
+  integrity sha512-wgCw1OO/iQ3w13WVRhx1fHoo5NDHq+444wqTnKcAWA9YMj1a9stoLlfLjW1mJJkFG1aRjeKd9KYhiYOJ3H7qEg==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
From @quochuy #116:

> Automatically rotate images that were taken in portrait mode from a mobile phone
> 
> Photos taken from a mobile phone in portrait mode have an EXIF metadata that tells the viewing software (in this case the browser) to rotate the image. However, the image proxy does not perform the rotation.
> 
> **Example of the issue**
> Example image from https://steemit.com/wales/@trystan/rest-in-peace-dad-rip-wales
> 
> Original image (notice that the image is correctly oriented): 
> https://cdn.steemitimages.com/DQmTssGEdhm4RiuHTwqn7KoT78ZdadWKLFjSTeXvU5gSTyi/90FD4E69-3CE8-478A-A8C2-6044EAF86FAD.jpeg
> 
> Proxied image (noticed it is now rotated 90 degrees to the left):
> https://steemitimages.com/640x0/https://cdn.steemitimages.com/DQmTssGEdhm4RiuHTwqn7KoT78ZdadWKLFjSTeXvU5gSTyi/90FD4E69-3CE8-478A-A8C2-6044EAF86FAD.jpeg
> 
> After the fix, it's now resized to 640x0 and correctly oriented:
> ![Screen Shot 2019-12-16 at 8 32 31 pm](https://user-images.githubusercontent.com/310654/70895603-5b9af100-2043-11ea-9350-41597ff97f68.jpg)
> 
> **Counter test**
> I've tested against an original landscape image and it does not perform a extra rotation, the image is correctly oriented.
> 
> **Got the hint from:**
> https://github.com/lovell/sharp/issues/903
> 